### PR TITLE
Update jsDelivr link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@
 
 npm: `npm install mo-js`
 
-cdn: `<script src="//cdn.jsdelivr.net/mojs/latest/mo.min.js"></script>`  
+cdn: `<script src="https://cdn.jsdelivr.net/npm/mo-js@latest/build/mo.min.js"></script>`  
 
 bower: `bower install mojs`
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version. You can always find the correct link at https://www.jsdelivr.com/package/npm/mo-js.

Feel free to ping me if you have any questions regarding this change.