### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "authors": [
     "Oleg Solomka @legomushroom <legomushroom@gmail.com>"
   ],
-  "main": "build/mo.min.js",
+  "main": "build/mo.js",
   "keywords": [
     "motion",
     "graphics",


### PR DESCRIPTION
invalid-meta The "main" field cannot contain minified files - it would seem that the best practice for bower is to provide the files in un-minified format and allow the end user to minify them along with their own files.