### PR TITLE
Replaced non functional codepens with new ones

### DIFF
--- a/api/utils/stagger.md
+++ b/api/utils/stagger.md
@@ -2,7 +2,7 @@
 
 References:
 
-- [CodePen Example](https://codepen.io/sol0mka/pen/68c596ca7444cb3df7b66b84fb1fd5c6?editors=0010)
+- [CodePen Example](https://codepen.io/sandstedt/pen/qwGWjv?editors=0010)
 - [back](/api)
 
 Contents:
@@ -27,7 +27,7 @@ const shapes = new Shapes({
 
 ```
 
-[CodePen Example](https://codepen.io/sol0mka/pen/81885a6b6125bc73b0665b5816b12012?editors=0010)
+[CodePen Example](https://codepen.io/sandstedt/pen/VNOZbo?editors=0010)
 
 You can use `array` to specify property value for each shape:
 
@@ -44,7 +44,7 @@ const shapes = new StaggeredShape({
 
 ```
 
-[CodePen Example](https://codepen.io/sol0mka/pen/78c17f405451e644cb424db364266015?editors=0010)
+[CodePen Example](https://codepen.io/sandstedt/pen/GLaKWJ?editors=0010)
 
 You can use `stagger` string incremental properties:
 
@@ -61,7 +61,7 @@ const shapes = new StaggeredShape({
 
 ```
 
-[CodePen Example](https://codepen.io/sol0mka/pen/dd71c464c891b79b561b663f31c17804?editors=0010)
+[CodePen Example](https://codepen.io/sandstedt/pen/gyJYGr?editors=0010)
 
 The `initial value` could be omitted - it will fallback to `0`:
 
@@ -97,7 +97,7 @@ const shapes = new StaggeredShape({
 
 ```
 
-[CodePen Example](https://codepen.io/sol0mka/pen/097474f0a97e492adf87fc24b68cf05c?editors=0010)
+[CodePen Example](https://codepen.io/sandstedt/pen/zXQORM?editors=0010)
 
 ### Full API Reference
 


### PR DESCRIPTION
These one has been forked from Legomushrooms private pens that had a reference to a dropboxcontent file instead of a CDN.