### PR TITLE
Fix tutorial and tool links

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ The library provides **built-in components** to start animating from scratch lik
 - [Simple Ripple](https://codepen.io/sol0mka/full/XKdWJg/) (click to see)
 
 ## Tutorials
-- Shape & Swirl (broken link) [API/shape](/api/shape.md)
-- Burst (broken link) [API/burst](/api/burst.md)
-- Path Easing (broken link) [API/easing/path-easing](/api/easing/path-easing.md)
+- [Shape & Swirl](https://mojs.github.io/tutorials/shape-swirl/)
+- [Burst](https://mojs.github.io/tutorials/burst/)
+- Path Easing (coming soon) [API/easing/path-easing](/api/easing/path-easing.md)
 - [Video with MojsPlayer and MojsCurveEditor](https://vimeo.com/185587462)
 - [Icon Animations Powered by mo.js](https://tympanus.net/codrops/2016/02/23/icon-animations-powered-by-mo-js/)
 - [An Introduction to mo.js, by Sarah Drasner](https://css-tricks.com/introduction-mo-js/)
@@ -43,9 +43,9 @@ The library provides **built-in components** to start animating from scratch lik
 - [Reference](/api)
 
 ## Tools
-- [Player](https://github.com/mojs-contrib/mojs-player)
-- [Curve editor](https://github.com/mojs-contrib/mojs-curve-editor)
-- [Timeline editor](https://github.com/mojs-contrib/mojs-timeline-editor)
+- [Player](https://github.com/mojs/mojs-player)
+- [Curve editor](https://github.com/mojs/mojs-curve-editor)
+- [Timeline editor](https://github.com/mojs/mojs-timeline-editor)
 
 ## Installation
 ```console


### PR DESCRIPTION
Use `mojs.github.io` and the official `mojs` repository links in the readme.