### PR TITLE
fix(bezier-easing): change check on Float32Array availability to work in strict mode (#126)

### DIFF
--- a/js/easing/bezier-easing.coffee
+++ b/js/easing/bezier-easing.coffee
@@ -28,7 +28,7 @@ class BezierEasing
     SUBDIVISION_MAX_ITERATIONS = 10
     kSplineTableSize = 11
     kSampleStepSize = 1.0 / (kSplineTableSize - 1.0)
-    float32ArraySupported = 'Float32Array' in global
+    float32ArraySupported = !!Float32Array
 
     A = (aA1, aA2) -> 1.0 - 3.0 * aA2 + 3.0 * aA1
     B = (aA1, aA2) -> 3.0 * aA2 - 6.0 * aA1


### PR DESCRIPTION
I ran into this as well when upgrading Angular 8 -> 9. Switch from checking global to using a double bang to check if Float32Array is a truthy value.