### PR TITLE
Angle to rotate

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,59 +2,62 @@ process.env.CHROME_BIN = require('puppeteer').executablePath();
 
 module.exports = (config) => {
 
-  // browser testing configuration
-  let customLaunchers = {
-    bs_chrome_latest: {
-      browser: 'chrome',
-      os: 'Windows',
-      os_version: '10',
-    },
-    bs_firefox_latest: {
-      browser: 'firefox',
-      os: 'Windows',
-      os_version: '10',
-    },
-    bs_edge_latest: {
-      browser: 'edge',
-      os: 'Windows',
-      os_version: '10',
-    },
-    bs_safari_latest: {
-      browser: 'safari',
-      os: 'OS X',
-      os_version: 'Catalina',
-    },
-    bs_iphone_latest: {
-      device: 'iPhone 11',
-      os: 'iOS',
-      os_version: '14',
-    },
-  };
-
-  const ChromeHeadlessNoSandbox = {
-    base: 'ChromeHeadless',
-    flags: ['--no-sandbox'],
-  };
-
-  // define the base configuration for each launcher
-  Object.keys(customLaunchers).map((key) => {
-    customLaunchers[key].base = 'BrowserStack';
-    customLaunchers[key].browser_version = 'latest';
-  });
-
   // use appropriate reporter if running with GITHUB_ACTIONS
-  let reporters, browsers;
+  let customLaunchers, reporters, browsers;
 
+  // run tests against browsers on Github Actions, ChromeHeadless instead
   if (process.env.GITHUB_ACTIONS) {
-    reporters = ['BrowserStack', 'summary', 'coverage'];
-    browsers = Object.keys(customLaunchers);
-  } else {
+    customLaunchers = {
+      bs_chrome_latest: {
+        browser: 'chrome',
+        os: 'Windows',
+        os_version: '10',
+      },
+      bs_firefox_latest: {
+        browser: 'firefox',
+        os: 'Windows',
+        os_version: '10',
+      },
+      bs_edge_latest: {
+        browser: 'edge',
+        os: 'Windows',
+        os_version: '10',
+      },
+      bs_safari_latest: {
+        browser: 'safari',
+        os: 'OS X',
+        os_version: 'Catalina',
+      },
+      bs_iphone_latest: {
+        device: 'iPhone 11',
+        os: 'iOS',
+        os_version: '14',
+      },
+    };
 
-    // Here you can change to what browsers you have on your system. TODO: Move to .env file instead
-    // Note: Puppetter currently doesn't work on WSL v1. Should work in WSL v2
+    // define the base configuration for each launcher
+    Object.keys(customLaunchers).map((key) => {
+      customLaunchers[key].base = 'BrowserStack';
+      customLaunchers[key].browser_version = 'latest';
+    });
+
+    reporters = ['BrowserStack', 'summary', 'coverage'];
+  } else {
+    customLaunchers = {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: [
+          '--no-sandbox',
+          '--single-process',
+        ],
+      },
+    };
+
     reporters = ['progress', 'coverage'];
-    browsers = ChromeHeadlessNoSandbox;
   }
+
+  // build a list of browsers to run the test
+  browsers = Object.keys(customLaunchers);
 
   config.set({
     basePath: '',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,6 +31,11 @@ module.exports = (config) => {
     },
   };
 
+  const ChromeHeadlessNoSandbox = {
+    base: 'ChromeHeadless',
+    flags: ['--no-sandbox'],
+  };
+
   // define the base configuration for each launcher
   Object.keys(customLaunchers).map((key) => {
     customLaunchers[key].base = 'BrowserStack';
@@ -48,7 +53,7 @@ module.exports = (config) => {
     // Here you can change to what browsers you have on your system. TODO: Move to .env file instead
     // Note: Puppetter currently doesn't work on WSL v1. Should work in WSL v2
     reporters = ['progress', 'coverage'];
-    browsers = ['ChromeHeadless'];
+    browsers = ChromeHeadlessNoSandbox;
   }
 
   config.set({

--- a/spec/burst.coffee
+++ b/spec/burst.coffee
@@ -316,89 +316,89 @@ describe 'Burst ->', ->
       expect(isClose or isZero).toBe true
       expect(obj1.y[0]).toBeCloseTo 100, 5
 
-    it 'should add angles ->', ->
+    it 'should add rotations ->', ->
       burst = new Burst
         radius: { 0: 100 }
         count:  2
 
-      obj0 = { angle: 0 }
-      obj1 = { angle: 0 }
+      obj0 = { rotate: 0 }
+      obj1 = { rotate: 0 }
       result0 = burst._addOptionalProps obj0, 0
       result1 = burst._addOptionalProps obj1, 1
 
-      expect(obj0.angle).toBe 90
-      expect(obj1.angle).toBe 270
+      expect(obj0.rotate).toBe 90
+      expect(obj1.rotate).toBe 270
 
-  describe '_getBitAngle method ->', ->
-    it 'should get angle by i', ->
+  describe '_getBitRotation method ->', ->
+    it 'should get rotation by i', ->
       burst = new Burst radius: { 'rand(10,20)': 100 }
-      expect(burst._getBitAngle(0,  0, 0)).toBe 90
-      expect(burst._getBitAngle(0,  0, 1)).toBe 162
-      expect(burst._getBitAngle(0,  0, 2)).toBe 234
-      expect(burst._getBitAngle(90, 0, 2)).toBe 234 + 90
-      expect(burst._getBitAngle(0,  0, 3)).toBe 306
-      expect(burst._getBitAngle(90, 0, 3)).toBe 306 + 90
-      expect(burst._getBitAngle(0,  0, 4)).toBe 378
-      expect(burst._getBitAngle(50, 0, 4)).toBe 378 + 50
+      expect(burst._getBitRotation(0,  0, 0)).toBe 90
+      expect(burst._getBitRotation(0,  0, 1)).toBe 162
+      expect(burst._getBitRotation(0,  0, 2)).toBe 234
+      expect(burst._getBitRotation(90, 0, 2)).toBe 234 + 90
+      expect(burst._getBitRotation(0,  0, 3)).toBe 306
+      expect(burst._getBitRotation(90, 0, 3)).toBe 306 + 90
+      expect(burst._getBitRotation(0,  0, 4)).toBe 378
+      expect(burst._getBitRotation(50, 0, 4)).toBe 378 + 50
 
-    it 'should add with angleShift', ->
+    it 'should add with rotationShift', ->
       burst = new Burst radius: { 'rand(10,20)': 100 }
-      expect(burst._getBitAngle(0,  0, 0)).toBe 90
-      expect(burst._getBitAngle(0,  10, 1)).toBe 162 + 10
-      expect(burst._getBitAngle(0,  30, 2)).toBe 234 + 30
-      expect(burst._getBitAngle(90, 40, 2)).toBe 234 + 90 + 40
-      expect(burst._getBitAngle(0,  20, 3)).toBe 306 + 20
-      expect(burst._getBitAngle(90, 25, 3)).toBe 306 + 90 + 25
-      expect(burst._getBitAngle(0,  10, 4)).toBe 378 + 10
-      expect(burst._getBitAngle(50, 60, 4)).toBe 378 + 50 + 60
+      expect(burst._getBitRotation(0,  0, 0)).toBe 90
+      expect(burst._getBitRotation(0,  10, 1)).toBe 162 + 10
+      expect(burst._getBitRotation(0,  30, 2)).toBe 234 + 30
+      expect(burst._getBitRotation(90, 40, 2)).toBe 234 + 90 + 40
+      expect(burst._getBitRotation(0,  20, 3)).toBe 306 + 20
+      expect(burst._getBitRotation(90, 25, 3)).toBe 306 + 90 + 25
+      expect(burst._getBitRotation(0,  10, 4)).toBe 378 + 10
+      expect(burst._getBitRotation(50, 60, 4)).toBe 378 + 50 + 60
     it 'should fallback to 0', ->
       burst = new Burst radius: { 'rand(10,20)': 100 }
-      expect(burst._getBitAngle(undefined, 0, 0)).toBe 90
-      expect(burst._getBitAngle(undefined, 0, 1)).toBe 162
-      expect(burst._getBitAngle(undefined, 0, 2)).toBe 234
-    it 'should get delta angle by i', ->
+      expect(burst._getBitRotation(undefined, 0, 0)).toBe 90
+      expect(burst._getBitRotation(undefined, 0, 1)).toBe 162
+      expect(burst._getBitRotation(undefined, 0, 2)).toBe 234
+    it 'should get delta rotation by i', ->
       burst = new Burst radius: { 'rand(10,20)': 100 }
-      expect(burst._getBitAngle({180:0}, 0, 0)[270]).toBe 90
-      expect(burst._getBitAngle({50:20}, 0, 3)[356]).toBe 326
-      expect(burst._getBitAngle({50:20}, 0, 4)[428]).toBe 398
+      expect(burst._getBitRotation({180:0}, 0, 0)[270]).toBe 90
+      expect(burst._getBitRotation({50:20}, 0, 3)[356]).toBe 326
+      expect(burst._getBitRotation({50:20}, 0, 4)[428]).toBe 398
 
-    it 'should add angleShift to deltas', ->
+    it 'should add rotationShift to deltas', ->
       burst = new Burst radius: { 'rand(10,20)': 100 }
-      expect(burst._getBitAngle({180:0}, 20, 0)[270 + 20]).toBe 90 + 20
-      expect(burst._getBitAngle({50:20}, 30, 3)[356 + 30]).toBe 326 + 30
-      expect(burst._getBitAngle({50:20}, 50, 4)[428 + 50]).toBe 398 + 50
+      expect(burst._getBitRotation({180:0}, 20, 0)[270 + 20]).toBe 90 + 20
+      expect(burst._getBitRotation({50:20}, 30, 3)[356 + 30]).toBe 326 + 30
+      expect(burst._getBitRotation({50:20}, 50, 4)[428 + 50]).toBe 398 + 50
 
     it 'should work with `stagger` values', ->
       burst = new Burst count: 2
 
-      expect(burst._getBitAngle({'stagger(20, 10)':0}, 0, 0)[110]).toBe 90
-      expect(burst._getBitAngle({'stagger(20, 10)':0}, 0, 1)[300]).toBe 270
+      expect(burst._getBitRotation({'stagger(20, 10)':0}, 0, 0)[110]).toBe 90
+      expect(burst._getBitRotation({'stagger(20, 10)':0}, 0, 1)[300]).toBe 270
 
-      expect(burst._getBitAngle({0:'stagger(20, 10)'}, 0, 1)[270]).toBe 300
+      expect(burst._getBitRotation({0:'stagger(20, 10)'}, 0, 1)[270]).toBe 300
 
     it 'should work with `random` values', ->
       burst = new Burst count: 2
 
-      angle = burst._getBitAngle({'rand(10, 20)':0}, 0, 0)
-      for key, value in angle
-        baseAngle = 90
-        expect(parseInt(key)).toBeGreaterThan  baseAngle + 10
-        expect(parseInt(key)).not.toBeGreaterThan baseAngle + 20
-        expect(parseInt(value)).toBe baseAngle
+      rotation = burst._getBitRotation({'rand(10, 20)':0}, 0, 0)
+      for key, value in rotation
+        baseRotation = 90
+        expect(parseInt(key)).toBeGreaterThan  baseRotation + 10
+        expect(parseInt(key)).not.toBeGreaterThan baseRotation + 20
+        expect(parseInt(value)).toBe baseRotation
 
-      angle = burst._getBitAngle({'rand(10, 20)':0}, 0, 1)
-      for key, value in angle
-        baseAngle = 270
-        expect(parseInt(key)).toBeGreaterThan  baseAngle + 10
-        expect(parseInt(key)).not.toBeGreaterThan baseAngle + 20
-        expect(parseInt(value)).toBe baseAngle
+      rotation = burst._getBitRotation({'rand(10, 20)':0}, 0, 1)
+      for key, value in rotation
+        baseRotation = 270
+        expect(parseInt(key)).toBeGreaterThan  baseRotation + 10
+        expect(parseInt(key)).not.toBeGreaterThan baseRotation + 20
+        expect(parseInt(value)).toBe baseRotation
 
-      angle = burst._getBitAngle({0:'rand(10, 20)'}, 0, 1)
-      for key, value in angle
-        baseAngle = 270
-        expect(parseInt(key)).toBe baseAngle
-        expect(parseInt(value)).toBeGreaterThan  baseAngle + 10
-        expect(parseInt(value)).not.toBeGreaterThan baseAngle + 20
+      rotation = burst._getBitRotation({0:'rand(10, 20)'}, 0, 1)
+      for key, value in rotation
+        baseRotation = 270
+        expect(parseInt(key)).toBe baseRotation
+        expect(parseInt(value)).toBeGreaterThan  baseRotation + 10
+        expect(parseInt(value)).not.toBeGreaterThan baseRotation + 20
 
   describe '_getSidePoint method ->', ->
     it 'should return the side\'s point', ->
@@ -885,12 +885,12 @@ describe 'Burst ->', ->
 
 
   describe '_addBurstProperties method ->', ->
-    it 'should calculate bit angle', ->
+    it 'should calculate bit rotation', ->
       b = new Burst
-      angle = 20
-      obj = { angle: angle }
+      rotate = 20
+      obj = { rotate: rotate }
       b._addBurstProperties( obj, 1 )
-      expect( obj.angle ).toBe b._getBitAngle( angle, 0, 1 )
+      expect( obj.rotate ).toBe b._getBitRotation( rotate, 0, 1 )
 
     it 'should calculate bit x and y', ->
       index = 1
@@ -910,19 +910,19 @@ describe 'Burst ->', ->
     # nope
     # it 'should set degreeShift to 0', ->
     #   b = new Burst
-    #   angle = 20
-    #   obj = { degreeShift: angle }
+    #   rotate = 20
+    #   obj = { degreeShift: rotate }
     #   b._addBurstProperties( obj, 1 )
     #   expect( obj.degreeShift ).toBe 0
 
-    it 'should calculate bit x/y and angle regarding degreeShift', ->
+    it 'should calculate bit x/y and rotation regarding degreeShift', ->
       index = 1
-      angle = 20
+      rotate = 20
       degreeShifts = [ 0, 10, 20 ]
       b = new Burst children: { degreeShift: degreeShifts }
       # put degreeShift value back since we override it to `0`
       # in `_addBurstProperties` method
-      obj = { angle: angle, degreeShift: degreeShifts[index]  }
+      obj = { rotate: rotate, degreeShift: degreeShifts[index]  }
       b._addBurstProperties( obj, index )
 
       p           = b._props
@@ -933,15 +933,15 @@ describe 'Burst ->', ->
 
       expect( obj.x ).toEqual b._getDeltaFromPoints('x', pointStart, pointEnd)
       expect( obj.y ).toEqual b._getDeltaFromPoints('y', pointStart, pointEnd)
-      expect( obj.angle ).toEqual b._getBitAngle( angle + degreeShifts[ index ], 0, index )
+      expect( obj.rotate ).toEqual b._getBitRotation( rotate + degreeShifts[ index ], 0, index )
 
-    it 'should calculate bit x/y and angle regarding stagger', ->
+    it 'should calculate bit x/y and rotation regarding stagger', ->
       index = 2
-      angle = 20
+      rotate = 20
       b = new Burst children: { degreeShift: 'stagger(200)' }
       # put degreeShift value back since we override it to `0`
       # in `_addBurstProperties` method
-      obj = { angle: angle, degreeShift: 'stagger(200)'  }
+      obj = { rotate: rotate, degreeShift: 'stagger(200)'  }
       b._addBurstProperties( obj, index )
 
       p           = b._props
@@ -952,9 +952,9 @@ describe 'Burst ->', ->
 
       expect( obj.x ).toEqual b._getDeltaFromPoints('x', pointStart, pointEnd)
       expect( obj.y ).toEqual b._getDeltaFromPoints('y', pointStart, pointEnd)
-      expect( obj.angle ).toEqual b._getBitAngle( angle + 400, 0, index )
+      expect( obj.rotate ).toEqual b._getBitRotation( rotate + 400, 0, index )
 
-    it 'should fallback to 0 for angle', ->
+    it 'should fallback to 0 for rotation', ->
       index = 2
       b = new Burst children: { degreeShift: 'stagger(200)' }
       # put degreeShift value back since we override it to `0`
@@ -968,7 +968,7 @@ describe 'Burst ->', ->
       pointStart  = b._getSidePoint('start', index*step + 400 );
       pointEnd    = b._getSidePoint('end',   index*step + 400 );
 
-      expect( obj.angle ).toEqual b._getBitAngle( 0, 400, index );
+      expect( obj.rotate ).toEqual b._getBitRotation( 0, 400, index );
 
     it 'should call _getSidePoint with passed index', ->
       b = new Burst count: 2

--- a/spec/h.coffee
+++ b/spec/h.coffee
@@ -815,7 +815,7 @@ describe 'Helpers ->', ->
       it 'should calculate radial point', ->
         point = h.getRadialPoint
           radius: 50
-          angle:  90
+          rotate:  90
           center: x: 50, y: 50
         expect(point.x).toBe 100
         expect(point.y).toBe 50
@@ -823,7 +823,7 @@ describe 'Helpers ->', ->
         point = h.getRadialPoint
           radius: 50
           radiusX:100
-          angle:  90
+          rotate:  90
           center: x: 50, y: 50
         expect(point.x).toBe 150
         expect(point.y).toBe 50
@@ -831,7 +831,7 @@ describe 'Helpers ->', ->
         point = h.getRadialPoint
           radius: 50
           radiusY:100
-          angle:  0
+          rotate:  0
           center: x: 50, y: 50
         expect(point.x).toBe 50
         expect(point.y).toBe -50
@@ -839,19 +839,19 @@ describe 'Helpers ->', ->
       # it 'should return false if 1 of 3 options missed', ->
       #   point = h.getRadialPoint
       #     radius: 50
-      #     angle:  90
+      #     rotate:  90
       #   expect(point).toBeFalsy()
       it 'should return false only if param is 0', ->
         point = h.getRadialPoint
           radius: 0
-          angle:  90
+          rotate:  90
           center: x: 0, y: 0
         expect(point).toBeTruthy()
       # nope
       # it 'should not return exponential forms', ->
       #   point = h.getRadialPoint
       #     radius: 0.00000001
-      #     angle:  90
+      #     rotate:  90
       #     center: x: 0.00000001, y: 0.00000001
       #   expect(point.x).not.toMatch /e/
       #   expect(point.y).not.toMatch /e/

--- a/spec/html.coffee
+++ b/spec/html.coffee
@@ -33,9 +33,9 @@ describe 'Html ->', ->
       expect( p['skewY'] ).toBe 0
 
       # expect( p['rotate'] ).toBe 0
-      expect( p['angleX'] ).toBe 0
-      expect( p['angleY'] ).toBe 0
-      expect( p['angleZ'] ).toBe 0
+      expect( p['rotateX'] ).toBe 0
+      expect( p['rotateY'] ).toBe 0
+      expect( p['rotateZ'] ).toBe 0
 
       expect( p['scale'] ).toBe  1
       expect( p['scaleX'] ).toBe 1
@@ -339,9 +339,9 @@ describe 'Html ->', ->
       expect( html._defaults.skewX ).toBe 0
       expect( html._defaults.skewY ).toBe 0
 
-      expect( html._defaults.angleX ).toBe 0
-      expect( html._defaults.angleY ).toBe 0
-      expect( html._defaults.angleZ ).toBe 0
+      expect( html._defaults.rotateX ).toBe 0
+      expect( html._defaults.rotateY ).toBe 0
+      expect( html._defaults.rotateZ ).toBe 0
 
       expect( html._defaults.scale ).toBe  1
       expect( html._defaults.scaleX ).toBe 1
@@ -365,7 +365,7 @@ describe 'Html ->', ->
       html._3dProperties = null
       html._declareDefaults()
 
-      expect( html._3dProperties ).toEqual [ 'angleX', 'angleY', 'z' ]
+      expect( html._3dProperties ).toEqual [ 'rotateX', 'rotateY', 'z' ]
 
     it 'should create _arrayPropertyMap object', ->
 
@@ -389,9 +389,9 @@ describe 'Html ->', ->
       expect( html._numberPropertyMap.scaleX ).toBe 1
       expect( html._numberPropertyMap.scaleY ).toBe 1
       # expect( html._numberPropertyMap.rotate ).toBe 1
-      expect( html._numberPropertyMap.angleX ).toBe 1
-      expect( html._numberPropertyMap.angleY ).toBe 1
-      expect( html._numberPropertyMap.angleZ ).toBe 1
+      expect( html._numberPropertyMap.rotateX ).toBe 1
+      expect( html._numberPropertyMap.rotateY ).toBe 1
+      expect( html._numberPropertyMap.rotateZ ).toBe 1
       expect( html._numberPropertyMap.skewX ).toBe 1
       expect( html._numberPropertyMap.skewY ).toBe 1
 

--- a/spec/module.coffee
+++ b/spec/module.coffee
@@ -19,7 +19,7 @@ describe 'module class ->', ->
       y:                0,
       rx:               0,
       ry:               0,
-      angle:            0,
+      rotate:           0,
       scale:            1,
       opacity:          1,
       points:           3,

--- a/spec/motion-path.coffee
+++ b/spec/motion-path.coffee
@@ -62,14 +62,14 @@ describe 'MotionPath ->', ->
     mp = new MotionPath
       path: 'M0.55859375,593.527344L0.55859375,593.527344'
       el: el
-    it 'have angle of 0', ->
+    it 'have rotate of 0', ->
       el = document.createElement 'div'
       mp = new MotionPath
         path: 'M0.55859375,593.527344L0.55859375,593.527344'
         el: el
         isRunLess: true
         isPresetPosition: false
-      expect(mp.angle).toBe 0
+      expect(mp.rotate).toBe 0
     it 'should have isCompositeLayer default of true', ->
       mp = new MotionPath
         path: 'M0.55859375,593.527344L0.55859375,593.527344'
@@ -117,14 +117,14 @@ describe 'MotionPath ->', ->
       expect(mp.defaults.yoyo)            .toBe false
       expect(mp.defaults.offsetX)         .toBe 0
       expect(mp.defaults.offsetY)         .toBe 0
-      expect(mp.defaults.angleOffset)     .toBe null
+      expect(mp.defaults.rotationOffset)     .toBe null
       expect(mp.defaults.pathStart)       .toBe 0
       expect(mp.defaults.pathEnd)         .toBe 1
       expect(mp.defaults.transformOrigin) .toBe null
 
       expect(mp.defaults.motionBlur)      .toBe 0
 
-      expect(mp.defaults.isAngle)         .toBe false
+      expect(mp.defaults.isRotation)         .toBe false
       expect(mp.defaults.isReverse)       .toBe false
       expect(mp.defaults.isRunLess)       .toBe false
       expect(mp.defaults.isPresetPosition).toBe true
@@ -331,22 +331,22 @@ describe 'MotionPath ->', ->
         setTimeout ->
           expect(isRightScope).toBe(true); dfr()
         , 500
-      it 'should be called with progress, x, y and angle', ->
-        progress = null; x = null; y = null; angle = null
+      it 'should be called with progress, x, y and rotate', ->
+        progress = null; x = null; y = null; rotate = null
         mp = new MotionPath
           path:       'M0,100 L100,0'
           el:         document.createElement 'div'
           isRunLess:  true,
           easing:     'linear.none',
           onUpdate:(p, o)->
-            progress = p; x = o.x; y = o.y; angle = o.angle
+            progress = p; x = o.x; y = o.y; rotate = o.rotate
 
         mp.timeline.setProgress .45
         mp.timeline.setProgress .5
         expect(progress.toFixed(1)).toBe '0.5'
         expect(x)       .toBeCloseTo 50, 5
         expect(y)       .toBeCloseTo 50, 5
-        expect(angle)   .toBeCloseTo 0, 5
+        expect(rotate)  .toBeCloseTo 0, 5
 
   describe 'fill ->', ->
     div = null; container = null
@@ -478,7 +478,7 @@ describe 'MotionPath ->', ->
         el: div
         offsetX: 10
         duration: 200
-        isAngle: true
+        isRotation: true
 
       setTimeout (->
         tr = mp.el.style.transform or mp.el.style["#{h.prefix.css}transform"]
@@ -532,47 +532,47 @@ describe 'MotionPath ->', ->
 
       setTimeout (-> expect(isEqual).toBe(true); dfr()), 500
 
-    it 'should calculate current angle', (dfr)->
+    it 'should calculate current rotation', (dfr)->
       coords = 'M0,0 L10,0 L10,10'
-      angle = 0; isEqual = false; isEquial2 = false; detect = {}
+      rotate = 0; isEqual = false; isEquial2 = false; detect = {}
       mp = new MotionPath
         path: coords
         el: div
         duration: 200
-        isAngle: true
+        isRotation: true
         onUpdate:->
-          detect.firstAngle ?= mp.angle
-          isEquial2 = detect.firstAngle is 0
-        onComplete:-> isEqual = mp.angle is 90
+          detect.firstRotation ?= mp.rotate
+          isEquial2 = detect.firstRotation is 0
+        onComplete:-> isEqual = mp.rotate is 90
       setTimeout (-> expect(isEqual).toBe(true); dfr()), 500
 
-    it 'should calculate current angle if transformOrigin is a fun', (dfr)->
+    it 'should calculate current rotation if transformOrigin is a fun', (dfr)->
       coords = 'M0,0 L10,0 L10,10'
-      angle = 0; isEqual = false; isEquial2 = false; detect = {}
+      rotate = 0; isEqual = false; isEquial2 = false; detect = {}
       mp = new MotionPath
         path: coords
         el: div
         duration: 200
         transformOrigin: ->
         onUpdate:->
-          detect.firstAngle ?= mp.angle
-          isEquial2 = detect.firstAngle is 0
-        onComplete:-> isEqual = mp.angle is 90
+          detect.firstRotation ?= mp.rotate
+          isEquial2 = detect.firstRotation is 0
+        onComplete:-> isEqual = mp.rotate is 90
       setTimeout (-> expect(isEqual).toBe(true); dfr()), 500
 
-    it 'should calculate current angle with isReverse', (dfr)->
+    it 'should calculate current rotation with isReverse', (dfr)->
       coords = 'M0,0 L10,0 L10,10'
-      angle = 0; isEqual = false; isEquial2 = false; detect = {}
+      rotate = 0; isEqual = false; isEquial2 = false; detect = {}
       mp = new MotionPath
         path: coords
         el: div
         duration: 200
-        isAngle: true
+        isRotation: true
         isReverse: true
         onUpdate:->
-          detect.firstAngle ?= mp.angle
-          isEquial2 = detect.firstAngle is 90
-        onComplete: -> isEqual = mp.angle is 0
+          detect.firstRotation ?= mp.rotate
+          isEquial2 = detect.firstRotation is 90
+        onComplete: -> isEqual = mp.rotate is 0
 
         setTimeout (-> expect(isEqual).toBe(true); dfr()), 500
 
@@ -594,44 +594,44 @@ describe 'MotionPath ->', ->
 
     it 'transform-origin could be a function', (dfr)->
       coords = 'M0,0 L10,0 L10,10'
-      isAngle = false; isProgress = false
+      isRotation = false; isProgress = false
       mp = new MotionPath
         path: coords
         el: div
         duration: 200
-        transformOrigin:(angle, proc)->
+        transformOrigin:(rotate, proc)->
           isFunction = true
-          isAngle = angle?; isProgress = proc?
+          isRotation = rotate?; isProgress = proc?
           '50% 50%'
-      setTimeout (-> expect(isAngle and isProgress).toBe(true); dfr()), 100
+      setTimeout (-> expect(isRotation and isProgress).toBe(true); dfr()), 100
 
-  describe 'angleOffset ->', ->
+  describe 'rotationOffset ->', ->
     div = document.createElement 'div'
-    it 'angleOffset should work with positive angles', (dfr)->
+    it 'rotationOffset should work with positive rotations', (dfr)->
       coords = 'M0,0 L10,0 L10,10'
       isEqual = false
       mp = new MotionPath
         path: coords
         el: div
         duration: 200
-        angleOffset: 90
-        isAngle: true
-        onComplete:-> isEqual = mp.angle is 180
+        rotationOffset: 90
+        isRotation: true
+        onComplete:-> isEqual = mp.rotate is 180
 
       setTimeout (-> expect(isEqual).toBe(true); dfr()), 500
 
-    it 'angleOffset should work with negative angles', (dfr)->
+    it 'rotationOffset should work with negative rotations', (dfr)->
       coords = 'M0,0 L10,0 L10,10'
       isEqual = false
       mp = new MotionPath
         path: coords
         el: div
         duration: 200
-        angleOffset: -90
-        isAngle: true
+        rotationOffset: -90
+        isRotation: true
         # onComplete:->
       setTimeout (->
-        isEqual = mp.angle is 0
+        isEqual = mp.rotate is 0
         expect(isEqual).toBe(true); dfr()
       ), 500
 
@@ -642,68 +642,68 @@ describe 'MotionPath ->', ->
         path: coords
         el: div
         duration: 200
-        angleOffset:(angle)->
+        rotationOffset:(rotate)->
           isFunction = true
-          angle
+          rotate
 
       setTimeout (-> expect(isFunction).toBe(true); dfr()), 500
 
-    it 'should get current angle', (dfr)->
+    it 'should get current rotation', (dfr)->
       coords = 'M0,0 L10,0 L10,10'
-      isOnAngle = null
-      angleSum1 = 0; angleSum2 = 0
+      isOnRotation = null
+      Sum1 = 0; Sum2 = 0
       mp = new MotionPath
         path: coords
         el: div
         duration: 200
-        isAngle: true
+        isRotation: true
         isRunLess: true
         isPresetPosition: false
-        angleOffset:(angle)->
-          angleSum1 += angle; angleSum2 += @angle
-          angle
-        onComplete:-> isOnAngle = angleSum1 is angleSum2
+        rotationOffset:(rotate)->
+          Sum1 += rotate; Sum2 += @rotate
+          rotate
+        onComplete:-> isOnRotation = Sum1 is Sum2
       mp.run()
-      setTimeout (-> expect(isOnAngle).toBe(true); dfr()), 500
+      setTimeout (-> expect(isOnRotation).toBe(true); dfr()), 500
 
-    it 'should set current angle', (dfr)->
+    it 'should set current rotation', (dfr)->
       coords = 'M0,0 L10,0 L10,10'
       isSet = false
-      currAngle = 0; isAnglesArray = []
-      angleShift = 5
+      currRotation = 0; isRotationsArray = []
+      rotationShift = 5
       mp = new MotionPath
         path: coords
         el: div
         duration: 200
-        angleOffset:(angle)-> currAngle = angle; angle+angleShift
-        onUpdate:-> isAnglesArray.push currAngle+angleShift is mp.angle
+        rotationOffset:(rotate)-> currRotation = rotate; rotate+rotationShift
+        onUpdate:-> isRotationsArray.push currRotation+rotationShift is mp.rotate
         onComplete:->
-          for isSetItem, i in isAnglesArray
+          for isSetItem, i in isRotationsArray
             if !isSetItem then isSet = true
 
       setTimeout (-> expect(isSet).toBe(false); dfr()), 500
 
-    it 'angleOffset should get current progress as second parameter', (dfr)->
+    it 'rotationOffset should get current progress as second parameter', (dfr)->
       coords = 'M0,0 L10,0 L10,10'
       isProgress = false; proc = -1
       mp = new MotionPath
         path: coords
         el: div
         duration: 200
-        angleOffset:(angle, progress)-> proc = progress; angle
+        rotationOffset:(rotate, progress)-> proc = progress; rotate
         onComplete:-> isProgress = proc is 1
       setTimeout (-> expect(isProgress).toBe(true); dfr()), 500
 
     it 'should have scope of motion path', ->
       coords = 'M0,0 L10,0 L10,10'
       isRightScope = false
-      angleSum1 = 0; angleSum2 = 0
+      Sum1 = 0; Sum2 = 0
       mp = new MotionPath
         path: coords
         el: div
         duration: 200
-        isAngle: true
-        angleOffset:-> isRightScope = @ instanceof MotionPath
+        isRotation: true
+        rotationOffset:-> isRightScope = @ instanceof MotionPath
 
       setTimeout ->
         expect(isRightScope).toBe(true)
@@ -1261,10 +1261,10 @@ describe 'MotionPath ->', ->
         isRunLess:  true
         isPresetPosition: false
       spyOn module, '_setProp'
-      mp.angle = 0
+      mp.rotate = 0
       mp.setModulePosition 100, 200
       expect(module._setProp).toHaveBeenCalledWith
-        shiftX: '100px', shiftY: '200px', angle: 0
+        shiftX: '100px', shiftY: '200px', rotate: 0
 
     it 'should call module.draw method', ->
       module = (new Shape isRunLess: true)
@@ -1588,7 +1588,7 @@ describe 'MotionPath ->', ->
   describe 'angToCoords method ->', ->
     path = "M0,20 L100,150 L200,100"
     degree45 = 1
-    it 'should translate angle to coordinates *y*', ->
+    it 'should translate rotation to coordinates *y*', ->
       mp = new MotionPath
         path:       path
         el:         document.createElement 'div'
@@ -1604,7 +1604,7 @@ describe 'MotionPath ->', ->
       expect(mp.angToCoords(315).y) .toBeCloseTo -degree45, 1
       expect(mp.angToCoords(-45).y) .toBeCloseTo -degree45, 1
       expect(mp.angToCoords(360).y) .toBeCloseTo -1
-    it 'should translate angle to coordinates *x*', ->
+    it 'should translate rotation to coordinates *x*', ->
       mp = new MotionPath
         path:       path
         el:         document.createElement 'div'

--- a/spec/shape-swirl.coffee
+++ b/spec/shape-swirl.coffee
@@ -18,18 +18,18 @@ describe 'ShapeSwirl ->', ->
     it 'should calc position radius', ->
       swirl = new ShapeSwirl x: {0:10}, y: {0:20}
       expect(swirl._posData.radius).toBe Math.sqrt (10*10 + 20*20)
-    it 'should calc position angle', ->
+    it 'should calc position rotation', ->
       swirl = new ShapeSwirl x: {0:10}, y: {0:10}
-      expect(swirl._posData.angle).toBe 135
-    it 'should calc position angle', ->
+      expect(swirl._posData.rotate).toBe 135
+    it 'should calc position rotation', ->
       swirl = new ShapeSwirl x: {0:-10}, y: {0:-10}
-      expect(swirl._posData.angle).toBe - 45
-    it 'should calc position angle', ->
+      expect(swirl._posData.rotate).toBe - 45
+    it 'should calc position rotation', ->
       swirl = new ShapeSwirl x: {0:0}, y: {0:-10}
-      expect(swirl._posData.angle).toBe 0
-    it 'should calc position angle', ->
+      expect(swirl._posData.rotate).toBe 0
+    it 'should calc position rotation', ->
       swirl = new ShapeSwirl x: {0:-10}, y: {0:0}
-      expect(swirl._posData.angle).toBe 270
+      expect(swirl._posData.rotate).toBe 270
     it 'should save startX and StartY values', ->
       swirl = new ShapeSwirl x: {0:10}, y: {10:10}
       expect(swirl._posData.x.start).toBe 0

--- a/spec/shape.coffee
+++ b/spec/shape.coffee
@@ -90,7 +90,7 @@ describe 'Shape ->', ->
       expect(byte._defaults.top).toBe              '50%'
       expect(byte._defaults.x).toBe                0
       expect(byte._defaults.y).toBe                0
-      expect(byte._defaults.angle).toBe            0
+      expect(byte._defaults.rotate).toBe           0
       expect(byte._defaults.scale).toEqual         1
       expect(byte._defaults.scaleX).toBe           null
       expect(byte._defaults.scaleY).toBe           null
@@ -717,10 +717,10 @@ describe 'Shape ->', ->
       byte = new Byte radius: 25
       byte.el = null
       expect(byte._drawEl()).toBe true
-    it 'should set transform if angle changed', ->
-      byte = new Byte angle: 25
+    it 'should set transform if rotation is changed', ->
+      byte = new Byte rotate: 25
       byte._draw()
-      byte._props.angle = 26
+      byte._props.rotate = 26
       byte._draw()
       style = byte.el.style
       tr = style['transform'] or style["#{mojs.h.prefix.css}transform"]
@@ -730,8 +730,8 @@ describe 'Shape ->', ->
       isTr4 = tr is 'translate(0px) rotate(26deg) scale(1)'
       expect(isTr or isTr2 or isTr3 or isTr4).toBe true
       # expect(byte.el.style["#{h.prefix.css}transform"]).toBe resultStr
-    it 'should not set transform if angle changed #2', ->
-      byte = new Byte angle: 25
+    it 'should not set transform if rotation changed #2', ->
+      byte = new Byte rotate: 25
       byte._draw()
       spyOn byte, '_fillTransform'
       byte._draw()
@@ -1106,7 +1106,7 @@ describe 'Shape ->', ->
 
   describe '_fillTransform method ->', ->
     it 'return tranform string of the el', ->
-      tr = new Shape x: 100, y: 100, angle: 50, scaleX: 2, scaleY: 3
+      tr = new Shape x: 100, y: 100, rotate: 50, scaleX: 2, scaleY: 3
       expect(tr._fillTransform())
         .toBe 'translate(100px, 100px) rotate(50deg) scale(2, 3)'
 

--- a/spec/shapes/bit.coffee
+++ b/spec/shapes/bit.coffee
@@ -140,7 +140,7 @@ describe 'Bit ->', ->
         'fill':                 '#0ff'
         'stroke-dasharray':     100
         'stroke-dashoffset':    50
-        'angle':                45
+        'rotate':               45
 
       bit._draw()
 
@@ -170,7 +170,7 @@ describe 'Bit ->', ->
         'stroke-dashoffset':  50
         'stroke-linecap':     'round'
         'stroke-opacity':     .5
-        angle:                45
+        rotate:               45
       bit._draw()
       expect(bit._state['stroke'])           .toBe '#0f0'
       expect(bit._state['stroke-width'])     .toBe 3
@@ -426,7 +426,7 @@ describe 'Bit ->', ->
   # #   it 'should calculate transform object', ->
   # #     bit = new Bit
   # #       ctx: svg
-  # #       angle: 90
+  # #       rotate: 90
   # #     expect(bit._props.transform).toBe('rotate(90, 0, 0)')
   # #     expect(bit.calcTransform).toBeDefined()
 

--- a/spec/tunable.coffee
+++ b/spec/tunable.coffee
@@ -20,7 +20,7 @@ describe 'Tunable ->', ->
         y:                0,
         rx:               0,
         ry:               0,
-        angle:            0,
+        rotate:           0,
         scale:            1,
         opacity:          1,
         points:           3,

--- a/src/burst.babel.js
+++ b/src/burst.babel.js
@@ -177,7 +177,7 @@ class Burst extends Tunable {
   }
 
   /*
-    Method to refresh burst x/y/angle options on further chained
+    Method to refresh burst x/y/rotate options on further chained
     swirls, because they will be overriden after `tune` call on
     very first swirl.
     @param {Array} Chained modules array
@@ -399,61 +399,61 @@ class Burst extends Tunable {
     options.x = this._getDeltaFromPoints('x', pointStart, pointEnd);
     options.y = this._getDeltaFromPoints('y', pointStart, pointEnd);
 
-    options.angle = this._getBitAngle((options.angle || 0), degreeShift, index);
+    options.rotate = this._getBitRotation((options.rotate || 0), degreeShift, index);
   }
 
   /*
-    Method to get shapes angle in burst so
+    Method to get shapes rotation in burst so
     it will follow circular shape.
 
-     @param    {Number, Object} Base angle.
-     @param    {Number}         Angle shift for the bit
+     @param    {Number, Object} Base rotation.
+     @param    {Number}         Rotation shift for the bit
      @param    {Number}         Shape's index in burst.
-     @returns  {Number}         Angle in burst.
+     @returns  {Number}         Rotation in burst.
   */
-  _getBitAngle(angleProperty = 0, angleShift = 0, i) {
+  _getBitRotation(rotationProperty = 0, rotationShift = 0, i) {
     var p = this._props,
       degCnt = (p.degree % 360 === 0) ? p.count : p.count - 1 || 1,
       step = p.degree / degCnt,
-      angle = i * step + 90;
+      rotate = i * step + 90;
 
-    angle += angleShift;
+    rotate += rotationShift;
 
     // if not delta option
-    if (!this._isDelta(angleProperty)) { angleProperty += angle; }
+    if (!this._isDelta(rotationProperty)) { rotationProperty += rotate; }
     else {
       var delta = {},
-        keys = Object.keys(angleProperty),
+        keys = Object.keys(rotationProperty),
         start = keys[0],
-        end = angleProperty[start];
+        end = rotationProperty[start];
 
       start = h.parseStringOption(start, i);
       end = h.parseStringOption(end, i);
 
       // new start = newEnd
-      delta[parseFloat(start) + angle] = parseFloat(end) + angle;
+      delta[parseFloat(start) + rotate] = parseFloat(end) + rotate;
 
-      angleProperty = delta;
+      rotationProperty = delta;
     }
-    return angleProperty;
+    return rotationProperty;
   }
 
   /*
     Method to get radial point on `start` or `end`.
     @private
     @param {String} Name of the side - [start, end].
-    @param {Number} Angle of the radial point.
+    @param {Number} Rotatation of the radial point.
     @param {Number} Index of the main swirl.
     @returns radial point.
   */
-  _getSidePoint(side, angle, i) {
+  _getSidePoint(side, rotate, i) {
     var sideRadius = this._getSideRadius(side, i);
 
     return h.getRadialPoint({
       radius: sideRadius.radius,
       radiusX: sideRadius.radiusX,
       radiusY: sideRadius.radiusY,
-      angle: angle,
+      rotate: rotate,
 
       // center:  { x: p.center, y: p.center }
       center: { x: 0,

--- a/src/h.coffee
+++ b/src/h.coffee
@@ -218,8 +218,8 @@ class Helpers
     bindArgs = Array::slice.call(arguments, 2)
     wrapper
   getRadialPoint:(o={})->
-    # return if !o.radius? or !o.angle? or !o.center?
-    radAngle = (o.angle-90)*0.017453292519943295 # Math.PI/180
+    # return if !o.radius? or !o.rotate? or !o.center?
+    radAngle = (o.rotate-90)*0.017453292519943295 # Math.PI/180
     radiusX = if o.radiusX? then o.radiusX else o.radius
     radiusY = if o.radiusY? then o.radiusY else o.radius
     point =

--- a/src/html.babel.js
+++ b/src/html.babel.js
@@ -31,10 +31,10 @@ class Html extends Thenable {
       skewX: 0,
       skewY: 0,
 
-      // angle:      0,
-      angleX: 0,
-      angleY: 0,
-      angleZ: 0,
+      // rotate:      0,
+      rotateX: 0,
+      rotateY: 0,
+      rotateZ: 0,
 
       scale: 1,
       scaleX: 1,
@@ -52,7 +52,7 @@ class Html extends Thenable {
     this._drawExclude = { el: 1 };
 
     // properties that cause 3d layer
-    this._3dProperties = ['angleX', 'angleY', 'z'];
+    this._3dProperties = ['rotateX', 'rotateY', 'z'];
 
     // properties that have array values
     this._arrayPropertyMap = { transformOrigin: 1,
@@ -65,10 +65,10 @@ class Html extends Thenable {
       scaleX: 1,
       scaleY: 1,
 
-      // angle: 1,
-      angleX: 1,
-      angleY: 1,
-      angleZ: 1,
+      // rotate: 1,
+      rotateX: 1,
+      rotateY: 1,
+      rotateZ: 1,
       skewX: 1,
       skewY: 1,
     };
@@ -156,8 +156,8 @@ class Html extends Thenable {
   _drawTransform() {
     const p = this._props;
     const string = (!this._is3d)
-      ? `translate(${p.x}, ${p.y}) rotate(${p.angleZ}deg) skew(${p.skewX}deg, ${p.skewY}deg) scale(${p.scaleX}, ${p.scaleY})`
-      : `translate3d(${p.x}, ${p.y}, ${p.z}) rotateX(${p.angleX}deg) rotateY(${p.angleY}deg) rotateZ(${p.angleZ}deg) skew(${p.skewX}deg, ${p.skewY}deg) scale(${p.scaleX}, ${p.scaleY})`;
+      ? `translate(${p.x}, ${p.y}) rotate(${p.rotateZ}deg) skew(${p.skewX}deg, ${p.skewY}deg) scale(${p.scaleX}, ${p.scaleY})`
+      : `translate3d(${p.x}, ${p.y}, ${p.z}) rotateX(${p.rotateX}deg) rotateY(${p.rotateY}deg) rotateZ(${p.rotateZ}deg) skew(${p.skewX}deg, ${p.skewY}deg) scale(${p.scaleX}, ${p.scaleY})`;
 
     this._setStyle('transform', string);
   }

--- a/src/motion-path.coffee
+++ b/src/motion-path.coffee
@@ -146,21 +146,21 @@ class MotionPath
     offsetY:          0
     # ---
 
-    # Defines angle offset for path curves
-    # @property   angleOffset
+    # Defines rotation offset for path curves
+    # @property   rotationOffset
     # @type       {Number, Function}
     # @example
     #   // function
     #   new MotionPath({
     #     //...
-    #     angleOffset: function(currentAngle) {
-    #       return if (currentAngle < 0) { 90 } else {-90}
+    #     rotationOffset: function(currentRotation) {
+    #       return if (currentRotation < 0) { 90 } else {-90}
     #     }
     #   });
     #
     # @codepen Number:    https://codepen.io/sol0mka/pen/JogzXw
     # @codepen Function:  https://codepen.io/sol0mka/pen/MYNxer
-    angleOffset:      null
+    rotationOffset:      null
     # ---
 
     # Defines lower bound for path coordinates in rangle *[0,1]*
@@ -204,7 +204,7 @@ class MotionPath
 
     # Defines transform-origin CSS property for **el**.
     # Can be defined by **string** or **function**.
-    # Function recieves current angle as agrumnet and
+    # Function recieves current rotation as agrumnet and
     # should return transform-origin value as a strin.
     #
     # @property   transformOrigin
@@ -213,9 +213,9 @@ class MotionPath
     #   // function
     #   new MotionPath({
     #     //...
-    #     isAngle: true,
-    #     transformOrigin: function (currentAngle) {
-    #       return  6*currentAngle + '% 0';
+    #     isRotation: true,
+    #     transformOrigin: function (currentRotation) {
+    #       return  6*currentRotation + '% 0';
     #     }
     #   });
     #
@@ -223,12 +223,12 @@ class MotionPath
     transformOrigin:  null
     # ---
 
-    # Defines if path curves angle should be set to el.
+    # Defines if path curves rotation should be set to el.
     #
-    # @property   isAngle
+    # @property   isRotation
     # @type       {Boolean}
     # @codepen https://codepen.io/sol0mka/pen/GgVexq/
-    isAngle:          false
+    isRotation:          false
     # ---
 
     # Defines motion path direction.
@@ -294,8 +294,8 @@ class MotionPath
 
     dX = o.shift.x; dY = o.shift.y
     radius = Math.sqrt(dX*dX + dY*dY); percent = radius/100
-    angle  = Math.atan(dY/dX)*(180/Math.PI) + 90
-    if o.shift.x < 0 then angle = angle + 180
+    rotation  = Math.atan(dY/dX)*(180/Math.PI) + 90
+    if o.shift.x < 0 then rotation = rotation + 180
 
     # get point on line between start end end
     curvatureX = h.parseUnit curvature.x
@@ -304,7 +304,7 @@ class MotionPath
     curveXPoint = h.getRadialPoint
       center: x: start.x, y: start.y
       radius: curvatureX
-      angle:  angle
+      rotate:  rotate
     # get control point with center in curveXPoint
     curvatureY = h.parseUnit curvature.y
     curvatureY = if curvatureY.unit is '%' then curvatureY.value*percent
@@ -312,7 +312,7 @@ class MotionPath
     curvePoint = h.getRadialPoint
       center: x: curveXPoint.x, y: curveXPoint.y
       radius: curvatureY
-      angle:  angle+90
+      rotate:  rotation+90
 
     path.setAttribute 'd', "M#{start.x},#{start.y}
        Q#{curvePoint.x},#{curvePoint.y}
@@ -323,7 +323,7 @@ class MotionPath
   postVars:->
     @props.pathStart = h.clamp @props.pathStart, 0, 1
     @props.pathEnd   = h.clamp @props.pathEnd, @props.pathStart, 1
-    @angle = 0; @speedX = 0; @speedY = 0; @blurX = 0; @blurY = 0
+    @rotate = 0; @speedX = 0; @speedY = 0; @blurX = 0; @blurY = 0
     @prevCoords = {}; @blurAmount = 20
     # clamp motionBlur in range of [0,1]
     @props.motionBlur = h.clamp @props.motionBlur, 0, 1
@@ -462,37 +462,37 @@ class MotionPath
     point = @path.getPointAtLength len
     # get x and y coordinates
     x = point.x + @props.offsetX; y = point.y + @props.offsetY
-    @_getCurrentAngle point, len, p
+    @_getCurrentRotation point, len, p
     @_setTransformOrigin(p)
     @_setTransform(x, y, p, isInit)
     @props.motionBlur and @makeMotionBlur(x, y)
   setElPosition:(x,y,p)->
-    rotate    = if @angle isnt 0 then "rotate(#{@angle}deg)" else ''
+    rotate    = if @rotate isnt 0 then "rotate(#{@rotate}deg)" else ''
     isComposite = @props.isCompositeLayer and h.is3d
     composite = if isComposite then 'translateZ(0)' else ''
     transform = "translate(#{x}px,#{y}px) #{rotate} #{composite}"
     h.setPrefixedStyle @el, 'transform', transform
   setModulePosition:(x, y)->
-    @el._setProp shiftX: "#{x}px", shiftY: "#{y}px", angle: @angle
+    @el._setProp shiftX: "#{x}px", shiftY: "#{y}px", rotate: @rotate
     @el._draw()
-  _getCurrentAngle:(point, len, p)->
+  _getCurrentRotation:(point, len, p)->
     isTransformFunOrigin = typeof @props.transformOrigin is 'function'
-    if @props.isAngle or @props.angleOffset? or isTransformFunOrigin
+    if @props.isRotation or @props.rotationOffset? or isTransformFunOrigin
       prevPoint = @path.getPointAtLength len - 1
       x1 = point.y - prevPoint.y; x2 = point.x - prevPoint.x
       atan = Math.atan(x1/x2); !isFinite(atan) and (atan = 0)
-      @angle = atan*h.RAD_TO_DEG
-      if (typeof @props.angleOffset) isnt 'function'
-        @angle += @props.angleOffset or 0
-      else @angle = @props.angleOffset.call @, @angle, p
-    else @angle = 0
+      @rotate = atan*h.RAD_TO_DEG
+      if (typeof @props.rotationOffset) isnt 'function'
+        @rotate += @props.rotationOffset or 0
+      else @rotate = @props.rotationOffset.call @, @rotate, p
+    else @rotate = 0
   _setTransform:(x,y,p,isInit)->
     # get real coordinates relative to container size
     if @scaler then x *= @scaler.x; y *= @scaler.y
     # call onUpdate but not on the very first(0 progress) call
     transform = null
-    if !isInit then transform = @onUpdate?(p, { x: x, y: y, angle: @angle })
-    # set position and angle
+    if !isInit then transform = @onUpdate?(p, { x: x, y: y, rotate: @rotate })
+    # set position and rotatation
     # 1: if motion path is for module
     if @isModule then @setModulePosition(x,y)
     # 2: if motion path is for DOM node
@@ -507,11 +507,11 @@ class MotionPath
       isTransformFunOrigin = typeof @props.transformOrigin is 'function'
       # transform origin could be a function
       tOrigin = if !isTransformFunOrigin then @props.transformOrigin
-      else @props.transformOrigin(@angle, p)
+      else @props.transformOrigin(@rotate, p)
       h.setPrefixedStyle @el, 'transform-origin', tOrigin
   makeMotionBlur:(x, y)->
     # if previous coords are not defined yet -- set speed to 0
-    tailAngle = 0; signX = 1; signY = 1
+    tailRotation = 0; signX = 1; signY = 1
     if !@prevCoords.x? or !@prevCoords.y? then @speedX = 0; @speedY = 0
     # else calculate speed based on the largest axes delta
     else
@@ -519,9 +519,9 @@ class MotionPath
       if dX > 0 then signX = -1
       if signX < 0 then signY = -1
       @speedX = Math.abs(dX); @speedY = Math.abs(dY)
-      tailAngle = Math.atan(dY/dX)*(180/Math.PI) + 90
-    absoluteAngle = tailAngle - @angle
-    coords = @angToCoords absoluteAngle
+      tailRotation = Math.atan(dY/dX)*(180/Math.PI) + 90
+    absoluteRotation = tailRotation - @rotate
+    coords = @rotToCoords absoluteRotation
     # get blur based on speed where 1px per 1ms is very fast
     # and motionBlur coefficient
     @blurX = h.clamp (@speedX/16)*@props.motionBlur, 0, 1
@@ -576,14 +576,14 @@ class MotionPath
 
   tuneOptions:(o)-> @extendOptions(o); @postVars()
 
-  angToCoords:(angle)->
-    angle = angle % 360
-    radAngle = ((angle-90)*Math.PI)/180
-    x = Math.cos(radAngle); y = Math.sin(radAngle)
+  rotToCoords:(rotation)->
+    rotation = rotation % 360
+    radRotation = ((rotation-90)*Math.PI)/180
+    x = Math.cos(radRotation); y = Math.sin(radRotation)
     x = if x < 0 then Math.max(x, -0.7) else Math.min(x, .7)
     y = if y < 0 then Math.max(y, -0.7) else Math.min(y, .7)
     x: x*1.428571429
     y: y*1.428571429
-    # x: Math.cos(radAngle), y: Math.sin(radAngle)
+    # x: Math.cos(radRotation), y: Math.sin(radRotation)
 
 module.exports = MotionPath

--- a/src/shape-swirl.babel.js
+++ b/src/shape-swirl.babel.js
@@ -86,11 +86,11 @@ class ShapeSwirl extends Shape {
   _calcPosData() {
     var x = this._getPosValue('x'),
       y = this._getPosValue('y'),
-      angle = (90 + Math.atan((y.delta / x.delta) || 0) * h.RAD_TO_DEG);
+      rotate = (90 + Math.atan((y.delta / x.delta) || 0) * h.RAD_TO_DEG);
 
     this._posData = {
       radius: Math.sqrt(x.delta * x.delta + y.delta * y.delta),
-      angle: (x.delta < 0) ? angle + 180 : angle,
+      rotate: (x.delta < 0) ? rotate + 180 : rotate,
       x,
       y,
     };
@@ -149,9 +149,9 @@ class ShapeSwirl extends Shape {
   */
   _calcSwirlXY(proc) {
     var p = this._props,
-      angle = this._posData.angle + p.degreeShift,
+      rotate = this._posData.rotate + p.degreeShift,
       point = h.getRadialPoint({
-        angle: (p.isSwirl) ? angle + this._getSwirl(proc) : angle,
+        rotate: (p.isSwirl) ? rotate + this._getSwirl(proc) : rotate,
         radius: proc * this._posData.radius * p.pathScale,
         center: {
           x: this._posData.x.start,

--- a/src/shape.babel.js
+++ b/src/shape.babel.js
@@ -72,7 +72,7 @@ class Shape extends Tunable {
       y: 0,
 
       // ∆ :: Possible values: [ number ]
-      angle: 0,
+      rotate: 0,
 
       // ∆ :: Possible values: [ number ]
       scale: 1,
@@ -331,7 +331,7 @@ class Shape extends Tunable {
         isScaleX = this._isPropChanged('scaleX'),
         isScaleY = this._isPropChanged('scaleY'),
         isScale = this._isPropChanged('scale'),
-        isRotate = this._isPropChanged('angle');
+        isRotate = this._isPropChanged('rotate');
 
       isScale = isScale || isScaleX || isScaleY;
 
@@ -586,7 +586,7 @@ class Shape extends Tunable {
       scaleX = (p.scaleX != null) ? p.scaleX : p.scale,
       scaleY = (p.scaleY != null) ? p.scaleY : p.scale,
       scale = `${scaleX}, ${scaleY}`;
-    return `translate(${p.x}, ${p.y}) rotate(${p.angle}deg) scale(${scale})`;
+    return `translate(${p.x}, ${p.y}) rotate(${p.rotate}deg) scale(${scale})`;
   }
 
   /*

--- a/src/shapes/polygon.coffee
+++ b/src/shapes/polygon.coffee
@@ -38,7 +38,7 @@ class Polygon extends Bit
           radius:   @_props.radius
           radiusX:  @_props.radiusX
           radiusY:  @_props.radiusY
-          angle:    (i*step)
+          rotate:    (i*step)
           center:   x: p.width/2, y: p.height/2
 
       d = ''


### PR DESCRIPTION
Changed API to rotate from angle to rotate to make it more user friendly, and keep it compliant with the CSS spec.

To keep the library consistent, I changed all other relevant names to. Also made sure that tests and inline documentation used the same words.

**Updated API:**
angle ➡ rotate
angleX, angleY, angleZ ➡ rotateX, rotateY, rotateZ

**Updated internal function names:**
angleOffset  ➡ rotationOffset
isAngle ➡ isRotation
angleShift ➡ rotationShift
angleProperty ➡ rotationProperty
_getBitRotation ➡ _getBitRotation
