### PR TITLE
Fixed decimal errors on iOS tests

### DIFF
--- a/spec/burst.coffee
+++ b/spec/burst.coffee
@@ -1065,8 +1065,10 @@ describe 'Burst ->', ->
       child2 = new ChildSwirl degreeShift: 20,  x: { 0: 200 }
       child1.setProgress( .45 ); child1.setProgress( .5 )
       child2.setProgress( .45 ); child2.setProgress( .5 )
-      expect(child1._props.x).toBe child2._props.x
-      expect(child1._props.y).toBe child2._props.y
+      child1Xvalue = h.strToArr(child1._props.x)[0].value
+      child2Xvalue = h.strToArr(child2._props.x)[0].value
+      expect(child1Xvalue).toBeCloseTo(child2Xvalue, 5) 
+      #expect(child1._props.y).toBeCloseTo(child2._props.y, 5)
 
   describe 'MainSwirl ->', ->
     ChildSwirl = Burst.ChildSwirl

--- a/spec/burst.coffee
+++ b/spec/burst.coffee
@@ -1067,8 +1067,10 @@ describe 'Burst ->', ->
       child2.setProgress( .45 ); child2.setProgress( .5 )
       child1Xvalue = h.strToArr(child1._props.x)[0].value
       child2Xvalue = h.strToArr(child2._props.x)[0].value
+      child1Yvalue = h.strToArr(child1._props.y)[0].value
+      child2Yvalue = h.strToArr(child2._props.y)[0].value
       expect(child1Xvalue).toBeCloseTo(child2Xvalue, 5) 
-      #expect(child1._props.y).toBeCloseTo(child2._props.y, 5)
+      expect(child1Yvalue).toBeCloseTo(child2Yvalue, 5)
 
   describe 'MainSwirl ->', ->
     ChildSwirl = Burst.ChildSwirl

--- a/spec/tween/tween.coffee
+++ b/spec/tween/tween.coffee
@@ -1465,7 +1465,7 @@ describe 'Tween ->', ->
 
 
       t._update t._props.startTime + timeShift + (duration/2)
-      expect(updateValue).toBe(.5)
+      expect(updateValue).toBeCloseTo(.5, 5)
       expect(updateDirection).toBe(true)
 
       expect(t._wasUknownUpdate).toBe(false)
@@ -3503,7 +3503,7 @@ describe 'Tween ->', ->
 
 
       t._update t._props.startTime + timeShift + (duration/2)
-      expect(updateValue).toBe(.5)
+      expect(updateValue).toBeCloseTo(.5, 5)
       expect(updateDirection).toBe(true)
       expect(updateYoyo).toBe(false)
 


### PR DESCRIPTION
When running the tests on iOS, sometimes we get small decimal indifferences, that causes the test to fail. So added more `.toBeCloseTo()` methods in the failing tests insted of `.toBe()`. Still has some tests that fails sometimes, but overall not that often than before.